### PR TITLE
依存関係の更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,17 +11,17 @@
   },
   "dependencies": {
     "@asseinfo/react-kanban": "^2.2.0",
-    "@tauri-apps/api": "^1.2.0",
+    "@tauri-apps/api": "^1.5.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^1.2.2",
-    "@types/node": "^18.7.10",
-    "@types/react": "^18.0.15",
-    "@types/react-dom": "^18.0.6",
-    "@vitejs/plugin-react": "^3.0.0",
-    "typescript": "^4.6.4",
-    "vite": "^4.0.0"
+    "@tauri-apps/cli": "^1.5.9",
+    "@types/node": "^20.11.5",
+    "@types/react": "^18.2.48",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.12"
   }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,21 +6,21 @@ authors = ["you"]
 license = ""
 repository = ""
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = { version = "1.2", features = [] }
+tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.2", features = ["api-all"] }
-sqlx = { version = "0.6.2", features = ["runtime-tokio-rustls", "sqlite", "migrate"] }
-tokio = { version = "1.23.0", features = ["full"] }
-futures = "0.3.25"
-directories = "4.0.1"
+tauri = { version = "1.5", features = ["api-all"] }
+sqlx = { version = "0.7.3", features = ["runtime-tokio-rustls", "sqlite", "migrate"] }
+tokio = { version = "1.36.0", features = ["full"] }
+futures = "0.3.30"
+directories = "5.0.1"
 
 [features]
 # by default Tauri runs in production mode


### PR DESCRIPTION
## 依存関係の更新

このPull Requestでは、プロジェクトの依存関係を最新バージョンに更新しています。

### 更新内容

#### Node.js依存関係
- @tauri-apps/api: 1.2.0 → 1.5.3
- @tauri-apps/cli: 1.2.2 → 1.5.9
- @types/node: 18.7.10 → 20.11.5
- @types/react: 18.0.15 → 18.2.48
- @types/react-dom: 18.0.6 → 18.2.18
- @vitejs/plugin-react: 3.0.0 → 4.2.1
- typescript: 4.6.4 → 5.3.3
- vite: 4.0.0 → 5.0.12

#### Rust依存関係
- tauri-build: 1.2 → 1.5
- tauri: 1.2 → 1.5
- sqlx: 0.6.2 → 0.7.3
- tokio: 1.23.0 → 1.36.0
- futures: 0.3.25 → 0.3.30
- directories: 4.0.1 → 5.0.1
- rust-version: 1.57 → 1.65

この更新により、セキュリティの向上、新機能の追加、パフォーマンスの改善が期待できます。
